### PR TITLE
Fix/msvc_compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Requirements
 ------------
 
 You first need to install the `Boost <http://www.boost.org>`_ libraries.
-You can compile your own local version or simply do on Linux:
+You can compile your own local version. This is a must for Windows/MSCV. On Linux you can simply install it via:
 
 ```
 $ sudo apt-get install libboost-dev
@@ -38,6 +38,7 @@ $ python3 -m venv --copies my_venv
 $ source my_venv/bin/activate
 ```
 
+#### Linux/MacOS
 You should then compile and install the ``psbody-mesh`` package using the Makefile.
 If you are using the system-wide ``Boost`` libraries:
 
@@ -49,6 +50,13 @@ or the libraries locally installed:
 
 ```
 $ BOOST_ROOT=/path/to/boost/libraries make all
+```
+
+#### Windows 
+
+The makefile will not work on Windows with MSVC. Not tested with neither CygWin nor MinGw. Execute the following instead:
+```
+python setup.py install boost-location=<path_to_your_boost>
 ```
 
 Testing

--- a/mesh/CMakeLists.txt
+++ b/mesh/CMakeLists.txt
@@ -80,6 +80,20 @@ target_compile_definitions(spatialsearch PRIVATE
     ${DEFINES_MESH_EXTENSIONS_WITH_CGAL_WITHOUT_LINK})
 
 
+    
+# visibility
+python_add_library(TARGET visibility SOURCES 
+    src/py_visibility.cpp
+    src/visibility.cpp
+    )
+target_include_directories(visibility PRIVATE 
+  ${libcgalroot}/include
+  ${NUMPY_INCLUDE_PATH}
+  ${Boost_INCLUDE_DIRS})
+set_property(TARGET visibility PROPERTY FOLDER "GeometryExt/")
+target_compile_definitions(visibility PRIVATE
+    ${DEFINES_MESH_EXTENSIONS_WITH_CGAL_WITHOUT_LINK})
+
 
 # serialization extensions
 
@@ -97,3 +111,4 @@ target_include_directories(loadobj PRIVATE
   ${NUMPY_INCLUDE_PATH}
   ${Boost_INCLUDE_DIRS})
 set_property(TARGET loadobj PROPERTY FOLDER "SerializationExt/")
+

--- a/mesh/cmake/thirdparty.cmake
+++ b/mesh/cmake/thirdparty.cmake
@@ -26,7 +26,7 @@ find_package(PythonInterp REQUIRED)
 
 # numpy
 execute_process(
-  COMMAND ${PYTHON_EXECUTABLE} -c "import numpy; print numpy.get_include()"
+  COMMAND ${PYTHON_EXECUTABLE} -c "import numpy; print(numpy.get_include())"
   OUTPUT_VARIABLE NUMPY_INCLUDE_PATH
   ERROR_VARIABLE  NUMPY_ERROR
   OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/mesh/src/visibility.cpp
+++ b/mesh/src/visibility.cpp
@@ -44,6 +44,13 @@ typedef AABB_triangle_traits::Point_and_primitive_id Point_and_Primitive_id;
 typedef CGAL::AABB_tree<AABB_triangle_traits> Tree;
 typedef Tree::Object_and_primitive_id Object_and_Primitive_id;
 
+// if we are on MSCV, we need to instantiate the extern variable ORIGIN otherwise there will be a linking error
+#ifdef _MSC_VER
+namespace CGAL {
+    const CGAL::Origin ORIGIN;
+};
+#endif
+
 #include "visibility.h"
 
 struct VisibilityTask{

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,9 @@ class build_deflate_cgal(Command):
 
         CGAL_dir_deflate = os.path.abspath(self.build_temp)
 
+        if os.name == 'nt': # if on windows, MSVC compiler will look for the Release folder
+            CGAL_dir_deflate = os.path.join(CGAL_dir_deflate, 'Release')
+
         log.info('[CGAL] deflating cgal from "%s" to "%s"', CGAL_archive, CGAL_dir_deflate)
         if not os.path.exists(os.path.join(CGAL_dir_deflate, 'CGAL-4.7')):
             import tarfile


### PR DESCRIPTION
This PR enables installation of this package on Windows using MSVC compiler. 

This involves two things: 
1) modification of the destination folder of `setup.py` into which CGAL will get unzipped, because MSVC expects it in a slightly different location 
2) modfiication of `visibility.cpp` to prevent linker errors on MSVC

The changes should not affect compilation on Linux and MacOS at all.
