### PR TITLE
Check for OpenGL before running meshviewer

### DIFF
--- a/bin/meshviewer
+++ b/bin/meshviewer
@@ -91,7 +91,8 @@ from psbody.mesh.meshviewer import (
     MESH_VIEWER_DEFAULT_HEIGHT,
     ZMQ_HOST,
     MeshViewerLocal,
-    MeshViewerRemote)
+    MeshViewerRemote,
+    _test_for_opengl)
 
 
 logging.basicConfig(level=logging.INFO)
@@ -374,6 +375,8 @@ def take_snapshot(client, args):
 
 
 if __name__ == "__main__":
-    args = parser_root.parse_args()
-    dispatch_command(args)
+    if _test_for_opengl():
+        args = parser_root.parse_args()
+        dispatch_command(args)
+
     sys.exit(0)

--- a/mesh/meshviewer.py
+++ b/mesh/meshviewer.py
@@ -95,14 +95,15 @@ def _run_self(args, stdin=None, stdout=None, stderr=None):
 
 
 def _test_for_opengl():
+    print("Checking OpenGL...")
     try:
-        # from OpenGL.GLUT import glutInit
         GLUT.glutInit()
     except Exception as e:
+        print("OpenGL not available")
         print(e, file=sys.stderr)
-        print('failure')
-    else:
-        print('success')
+        return False
+    print("Success!")
+    return True
 
 
 test_for_opengl_cached = None


### PR DESCRIPTION
Previously, the command would dispatch regardless of the OpenGL status.  In cases where OpenGL was unavailable, the process would continue, start the client, and then run into an OpenGL error. End-users would sometimes not be informed of errors.

This change checks for OpenGL prior to dispatch, alerting the user of any errors.