### PR TITLE
fixes for latest pip -(no such option --install-option)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ package_name := mesh_package
 all:
 	@echo "\033[0;36m----- [" ${package_name} "] Installing with the interpreter `which python` (version `python --version | cut -d' ' -f2`)\033[0m"
 	@pip install --upgrade -r requirements.txt && pip list
-	@pip install --no-deps --install-option="--boost-location=$$BOOST_INCLUDE_DIRS" --verbose --no-cache-dir .
+	@BOOST_ROOT=${BOOST_INCLUDE_DIRS} pip install --no-deps --verbose --no-cache-dir .
 
 import_tests:
 	@echo "\033[0;33m----- [" ${package_name} "] Performing import tests\033[0m"
@@ -24,18 +24,15 @@ unit_tests:
 
 tests: import_tests unit_tests
 
-# Creating source distribution
 sdist:
 	@echo "\033[0;33m----- [" ${package_name} "] Creating the source distribution\033[0m"
 	@python setup.py sdist
 
-# Creating wheel distribution
 wheel:
 	@echo "\033[0;33m----- [" ${package_name} "] Creating the wheel distribution\033[0m"
 	@pip install wheel
-	@python setup.py --verbose build_ext --boost-location=$$BOOST_INCLUDE_DIRS bdist_wheel
+	@BOOST_ROOT=${BOOST_INCLUDE_DIRS} python setup.py --verbose build_ext bdist_wheel
 
-# Build documentation
 documentation:
 	@echo "\033[0;33m----- [" ${package_name} "] Building Sphinx documentation\033[0m"
 	@pip install -U sphinx sphinx_bootstrap_theme


### PR DESCRIPTION
```shell
Usage:   
  pip install [options] <requirement specifier> [package-index-options] ...
  pip install [options] -r <requirements file> [package-index-options] ...
  pip install [options] [-e] <vcs project url> ...
  pip install [options] [-e] <local project path> ...
  pip install [options] <archive url/path> ...

no such option: --install-option

```


on ubuntu this works - 
**BOOST_INCLUDE_DIRS=/usr make all** 

we need some gitactions to build this - it's too painful for newbies
